### PR TITLE
Added 'first edit location' in the users' table

### DIFF
--- a/views/user_table.php
+++ b/views/user_table.php
@@ -8,6 +8,7 @@
     <th>Answered?</th>
     <th>Last note</th>
     <th>First Editor</th>
+    <th>First edit near</th>
 </tr>
 </thead>
 <tbody>
@@ -31,6 +32,7 @@
     <td><i class="large <?php echo $answered;?> icon"></i></td>
     <td><?php echo $row->note;?></td>
     <td><?php echo $row->first_changeset_editor;?></td>
+    <td><?php echo $row->first_edit_location;?></td>
 </tr>
 <?php endforeach; ?>
 </tbody>
@@ -40,7 +42,7 @@ $date = DateTime::createFromFormat('Ymd', $day);
 $previous = $date->sub(new DateInterval('P1D'))->format('Ymd');
 $next = $date->add(new DateInterval('P2D'))->format('Ymd');
 ?>
-<tr><th colspan="7">
+<tr><th colspan="8">
   <div class="ui right floated pagination menu">
     <a class="icon item" href="<?php echo Flight::request()->base.'/day/'.($previous)?>">
       <i class="left chevron icon"></i>


### PR DESCRIPTION
Seguendo il [consiglio di Volker in talk-it](https://lists.openstreetmap.org/pipermail/talk-it/2017-January/056866.html) questa potrebbe essere una banale visualizzazione già nella tabella del luogo del primo edit dell'utente.

Non so se possa aver senso implementare una regexp per togliere "(Italy)" siccome suppongo che quello ci sarà sempre in quanto i dati arrivano dall'RSS già filtrato per nazione... Ma è solo una supposizione in quanto non so come funzioni effettivamente il filtro di newestosm feed.